### PR TITLE
Add workflow file for Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build site with Hugo
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        hugo: ["0.80.0"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Download Hugo
+        run: |
+          wget https://github.com/gohugoio/hugo/releases/download/v${{ matrix.hugo }}/hugo_extended_${{ matrix.hugo }}_Linux-64bit.tar.gz
+          tar xvf hugo_extended_${{ matrix.hugo }}_Linux-64bit.tar.gz
+      - name: Build site
+        run: |
+          cd kotkt.nl
+          ../hugo
+      - name: Upload site as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: site
+          path: kotkt.nl/public/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # kotkt-website
 www.kotkt.nl
 
+![Build](https://github.com/esrg-knights/kotkt-website/workflows/Build/badge.svg)
+
 ## Introduction
 
 Welcome to the github repo of the website of the Knights of the Kitchen table. 


### PR DESCRIPTION
This creates a downloadable zip for each commit and pull request. Future work is to download this zip from Github Actions to our mail server and then host it from there. If this is in place the provided zip will be identical to the deployed website

If approved this will by copypasted to FC