### PR TITLE
Regression in Hugo 0.80 breaks download page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        hugo: ["0.80.0"]
+        hugo: ["0.79.1"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
0.79.1 does not contain this bug. The as of speaking most recent
version, 0.83.1, also suffers from this issue, so it is likely we have
to migrate something.